### PR TITLE
Add global event position for cross-aggregate replay

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,7 +20,8 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.1', '8.2', '8.3']
-    env: 
+    env:
+      DYNAMODB_ENDPOINT: 'http://dynamodb-local:8000'
       AWS_ACCESS_KEY_ID: 'none'
       AWS_SECRET_ACCESS_KEY: 'none'
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .phpunit.cache
+.phpunit.result.cache
 composer.lock
 coverage/
 infection.html

--- a/README.md
+++ b/README.md
@@ -119,9 +119,23 @@ $eventStore->visitEvents(new Criteria(), $eventVisitor);
 
 Events are visited in `GlobalPosition` order, so cross-aggregate replay reflects the exact interleaving in which events were appended.
 
+#### Resume Replay From a Checkpoint
+
+```php
+use Broadway\EventStore\Management\Criteria;
+
+$lastProcessedGlobalPosition = $eventStore->visitEventsAfterGlobalPosition(
+    Criteria::create(),
+    $checkpoint,
+    $eventVisitor
+);
+```
+
+This replays only events with `GlobalPosition > $checkpoint` and returns the last global position scanned from the ordered feed. If no events are replayed, it returns the input checkpoint unchanged.
+
 ## Replay Ordering
 
-Aggregate streams are ordered by `Playhead`. Cross-aggregate replay (`visitEvents`) uses `GlobalPosition`, assigned atomically per append batch and stored in a DynamoDB Global Secondary Index. Events are always visited in the order they were committed, regardless of aggregate ID.
+Aggregate streams are ordered by `Playhead`. Cross-aggregate replay (`visitEvents`, `visitEventsAfterGlobalPosition`) uses `GlobalPosition`, assigned atomically per append batch and stored in a DynamoDB Global Secondary Index. Events are always visited in the order they were committed, regardless of aggregate ID.
 
 ## Read Consistency
 
@@ -131,7 +145,7 @@ Aggregate stream reads (`load`, `loadFromPlayhead`) use eventually consistent re
 $eventStore = new DynamoDbEventStore($client, $inputBuilder, $normalizer, 'table', aggregateConsistentReads: true);
 ```
 
-Global replay reads (`visitEvents`) are always eventually consistent — DynamoDB Global Secondary Indexes do not support strongly consistent reads.
+Global replay reads (`visitEvents`, `visitEventsAfterGlobalPosition`) are always eventually consistent — DynamoDB Global Secondary Indexes do not support strongly consistent reads.
 
 ## Core Components
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ $eventStore = new DynamoDbEventStore(
     $inputBuilder,
     $normalizer,
     'events-table', // DynamoDB table name
-    aggregateConsistentReads: false // set true for strongly consistent aggregate reads
+    aggregateConsistentReads: false, // set true for strongly consistent aggregate reads
+    replayPageSize: 1000 // batch size used internally by visitEvents()
 );
 
 // Create the table (if it doesn't exist)
@@ -149,6 +150,8 @@ $eventStore = new DynamoDbEventStore($client, $inputBuilder, $normalizer, 'table
 ```
 
 Global replay reads (`visitEvents`, `loadReplayPageAfterGlobalPosition`) are always eventually consistent — DynamoDB Global Secondary Indexes do not support strongly consistent reads.
+
+`visitEvents()` drains replay pages using a constructor-configurable `replayPageSize`, which defaults to `1000`.
 
 ## Core Components
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ $eventStore = new DynamoDbEventStore(
     $client,
     $inputBuilder,
     $normalizer,
-    'events-table' // DynamoDB table name
+    'events-table', // DynamoDB table name
+    aggregateConsistentReads: false // set true for strongly consistent aggregate reads
 );
 
 // Create the table (if it doesn't exist)
@@ -76,6 +77,13 @@ The event store automatically creates a DynamoDB table with the following struct
 - **Partition Key**: `Id` (String) - The aggregate ID
 - **Sort Key**: `Playhead` (Number) - The event version number
 - **Billing Mode**: Pay-per-request
+
+Additional attributes written to each event row:
+
+- **Feed** (String) - Always `all`; used as the partition key of the global replay index
+- **GlobalPosition** (Number) - Monotonically increasing, assigned atomically at append time
+
+A Global Secondary Index (`Feed-GlobalPosition-index`) on `Feed` (HASH) + `GlobalPosition` (RANGE) enables ordered cross-aggregate replay.
 
 ### Usage
 
@@ -108,6 +116,22 @@ use Broadway\EventStore\Management\Criteria;
 
 $eventStore->visitEvents(new Criteria(), $eventVisitor);
 ```
+
+Events are visited in `GlobalPosition` order, so cross-aggregate replay reflects the exact interleaving in which events were appended.
+
+## Replay Ordering
+
+Aggregate streams are ordered by `Playhead`. Cross-aggregate replay (`visitEvents`) uses `GlobalPosition`, assigned atomically per append batch and stored in a DynamoDB Global Secondary Index. Events are always visited in the order they were committed, regardless of aggregate ID.
+
+## Read Consistency
+
+Aggregate stream reads (`load`, `loadFromPlayhead`) use eventually consistent reads by default. Pass `aggregateConsistentReads: true` to the constructor for strongly consistent aggregate reads:
+
+```php
+$eventStore = new DynamoDbEventStore($client, $inputBuilder, $normalizer, 'table', aggregateConsistentReads: true);
+```
+
+Global replay reads (`visitEvents`) are always eventually consistent — DynamoDB Global Secondary Indexes do not support strongly consistent reads.
 
 ## Core Components
 

--- a/README.md
+++ b/README.md
@@ -119,23 +119,26 @@ $eventStore->visitEvents(new Criteria(), $eventVisitor);
 
 Events are visited in `GlobalPosition` order, so cross-aggregate replay reflects the exact interleaving in which events were appended.
 
-#### Resume Replay From a Checkpoint
+#### Load Replay Pages
 
 ```php
 use Broadway\EventStore\Management\Criteria;
 
-$lastProcessedGlobalPosition = $eventStore->visitEventsAfterGlobalPosition(
-    Criteria::create(),
-    $checkpoint,
-    $eventVisitor
-);
+$page = $eventStore->loadReplayPageAfterGlobalPosition(Criteria::create(), $checkpoint, 500);
+
+foreach ($page->events() as $event) {
+    $projector->apply($event->message());
+}
+
+$checkpoint = $page->lastProcessedGlobalPosition();
+$hasMore    = $page->hasMore();
 ```
 
-This replays only events with `GlobalPosition > $checkpoint` and returns the last global position scanned from the ordered feed. If no events are replayed, it returns the input checkpoint unchanged.
+`$limit` bounds examined replay rows, not emitted events. `lastProcessedGlobalPosition()` advances across filtered rows, and `hasMore()` reflects DynamoDB continuation state for the bounded query.
 
 ## Replay Ordering
 
-Aggregate streams are ordered by `Playhead`. Cross-aggregate replay (`visitEvents`, `visitEventsAfterGlobalPosition`) uses `GlobalPosition`, assigned atomically per append batch and stored in a DynamoDB Global Secondary Index. Events are always visited in the order they were committed, regardless of aggregate ID.
+Aggregate streams are ordered by `Playhead`. Cross-aggregate replay (`visitEvents`, `loadReplayPageAfterGlobalPosition`) uses `GlobalPosition`, assigned atomically per append batch and stored in a DynamoDB Global Secondary Index. Events are always visited in the order they were committed, regardless of aggregate ID.
 
 ## Read Consistency
 
@@ -145,7 +148,7 @@ Aggregate stream reads (`load`, `loadFromPlayhead`) use eventually consistent re
 $eventStore = new DynamoDbEventStore($client, $inputBuilder, $normalizer, 'table', aggregateConsistentReads: true);
 ```
 
-Global replay reads (`visitEvents`, `visitEventsAfterGlobalPosition`) are always eventually consistent — DynamoDB Global Secondary Indexes do not support strongly consistent reads.
+Global replay reads (`visitEvents`, `loadReplayPageAfterGlobalPosition`) are always eventually consistent — DynamoDB Global Secondary Indexes do not support strongly consistent reads.
 
 ## Core Components
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "^9.5.0 || ^13.0.0",
+        "phpunit/phpunit": "^10.0",
         "symplify/easy-coding-standard": "^11.1.0 || ^12.0.0 || ^13.0.0",
         "symfony/polyfill-intl-grapheme": "^1.26.0",
         "phpstan/phpstan": "^1.8.0 || ^2.0.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  dynamodb-local:
+    image: amazon/dynamodb-local:latest
+    command: -jar DynamoDBLocal.jar -inMemory
+    ports:
+      - "8000:8000"

--- a/docs/migrating-to-global-position.md
+++ b/docs/migrating-to-global-position.md
@@ -9,11 +9,11 @@ Each event row now has two additional attributes:
 - **`Feed`** (String) — always `'all'`; the hash key of the global replay index
 - **`GlobalPosition`** (Number) — a monotonically increasing counter assigned atomically at append time
 
-A Global Secondary Index (`Feed-GlobalPosition-index`) on `(Feed, GlobalPosition)` enables `visitEvents` to return events in the order they were committed.
+A Global Secondary Index (`Feed-GlobalPosition-index`) on `(Feed, GlobalPosition)` enables `visitEvents` to return events in the order they were committed and `visitEventsAfterGlobalPosition` to resume ordered replay from a checkpoint.
 
 A special counter item (`Id=_counter, Playhead=0`) is maintained in the same table to allocate `GlobalPosition` ranges atomically.
 
-Existing rows without `Feed` and `GlobalPosition` will not appear in the GSI and will therefore be skipped by `visitEvents`.
+Existing rows without `Feed` and `GlobalPosition` will not appear in the GSI and will therefore be skipped by `visitEvents` and `visitEventsAfterGlobalPosition`.
 
 ---
 

--- a/docs/migrating-to-global-position.md
+++ b/docs/migrating-to-global-position.md
@@ -1,0 +1,311 @@
+# Migrating to GlobalPosition
+
+This guide covers how to migrate an existing DynamoDB event store table to the schema introduced by the `GlobalPosition` feature.
+
+## What Changed
+
+Each event row now has two additional attributes:
+
+- **`Feed`** (String) — always `'all'`; the hash key of the global replay index
+- **`GlobalPosition`** (Number) — a monotonically increasing counter assigned atomically at append time
+
+A Global Secondary Index (`Feed-GlobalPosition-index`) on `(Feed, GlobalPosition)` enables `visitEvents` to return events in the order they were committed.
+
+A special counter item (`Id=_counter, Playhead=0`) is maintained in the same table to allocate `GlobalPosition` ranges atomically.
+
+Existing rows without `Feed` and `GlobalPosition` will not appear in the GSI and will therefore be skipped by `visitEvents`.
+
+---
+
+## Before You Start
+
+**Choose a long-running environment.** DynamoDB scans are paginated (at most 1 MB per call) and a large table will take many minutes of round trips. Run the script somewhere with no hard execution time limit:
+
+- A CLI process on a server or developer machine
+- An ECS task or EC2 instance (spin up for the migration, terminate after)
+- An AWS Batch job
+
+Do not use Lambda. Its maximum execution timeout is 15 minutes, which will not be sufficient for any non-trivial table.
+
+**Sorting requires a two-pass approach.** To assign `GlobalPosition` values in `RecordedOn` order without loading all items into memory at once, the scan collects only the sort keys (RecordedOn + primary key) in the first pass, sorts them, then fetches or updates each item individually in sorted order. The sort keys are much smaller than full event items — roughly 70 bytes each — so a table with a million events needs around 70 MB for the key list.
+
+For extremely large tables (tens of millions of events), write the sort keys to a file instead and use an external sort tool (e.g. Unix `sort`) before the second pass.
+
+---
+
+## Option A: Table Swap (recommended)
+
+Stand up a new table with the new schema alongside the old one, replay all existing events through the new store, then cut over. No in-place modification of the original table is needed. Safe under concurrent writes because the old table remains read/write throughout.
+
+### Steps
+
+1. **Keep the old code running for writes** while you prepare the new table.
+
+2. **Create the new table** with a temporary name:
+
+   ```php
+   $newEventStore = new DynamoDbEventStore($client, $inputBuilder, $normalizer, 'events-table-v2');
+   $newEventStore->createTable();
+   ```
+
+3. **First pass — collect sort keys** from the old table, paginating until all pages are consumed:
+
+   ```php
+   $sortKeys         = [];
+   $lastEvaluatedKey = null;
+
+   do {
+       $params = ['TableName' => 'events-table'];
+
+       if (null !== $lastEvaluatedKey) {
+           $params['ExclusiveStartKey'] = $lastEvaluatedKey;
+       }
+
+       $result = $client->scan($params);
+
+       foreach ($result->getItems() as $item) {
+           if (!isset($item['Metadata'])) {
+               continue; // skip the _counter item if present
+           }
+
+           $sortKeys[] = [
+               'RecordedOn' => $item['RecordedOn']->getS(),
+               'Id'         => $item['Id']->getS(),
+               'Playhead'   => (int) $item['Playhead']->getN(),
+           ];
+       }
+
+       $lastEvaluatedKey = $result->getLastEvaluatedKey();
+   } while ([] !== $lastEvaluatedKey);
+   ```
+
+4. **Sort keys by `RecordedOn`** to approximate the original append order. The tiebreaker on `Id` and `Playhead` makes the sort stable when timestamps collide, which is required for idempotency:
+
+   ```php
+   usort($sortKeys, function ($a, $b) {
+       return $a['RecordedOn'] <=> $b['RecordedOn']
+           ?: $a['Id'] <=> $b['Id']
+           ?: $a['Playhead'] <=> $b['Playhead'];
+   });
+   ```
+
+5. **Second pass — fetch items in batches of 100 using `BatchGetItem` and replay in position order.** `BatchGetItem` does not guarantee that items come back in request order, so fetched items are sorted back into their global position order before replaying. Catch `DuplicatePlayheadException` to skip events already written, making the script safe to re-run:
+
+   ```php
+   // Build a lookup from (Id#Playhead) → global position for re-sorting fetched batches.
+   $positionMap = [];
+   foreach ($sortKeys as $position => $key) {
+       $positionMap[$key['Id'] . '#' . $key['Playhead']] = $position;
+   }
+
+   foreach (array_chunk($sortKeys, 100) as $chunk) {
+       $keys = array_map(fn($key) => [
+           'Id'       => new AttributeValue(['S' => $key['Id']]),
+           'Playhead' => new AttributeValue(['N' => (string) $key['Playhead']]),
+       ], $chunk);
+
+       // BatchGetItem may return fewer than requested if DynamoDB throttles.
+       // Retry unprocessed keys until all are fetched.
+       $fetched   = [];
+       $remaining = $keys;
+
+       while ([] !== $remaining) {
+           $result = $client->batchGetItem([
+               'RequestItems' => [
+                   'events-table' => ['Keys' => $remaining],
+               ],
+           ]);
+
+           foreach ($result->getResponses()['events-table'] ?? [] as $item) {
+               $fetched[] = $item;
+           }
+
+           // getUnprocessedKeys() returns array<string, KeysAndAttributes>; call getKeys() to get the array.
+           $remaining = $result->getUnprocessedKeys()['events-table']?->getKeys() ?? [];
+       }
+
+       // Restore global position order before replaying.
+       usort($fetched, function ($a, $b) use ($positionMap) {
+           $posA = $positionMap[$a['Id']->getS() . '#' . $a['Playhead']->getN()];
+           $posB = $positionMap[$b['Id']->getS() . '#' . $b['Playhead']->getN()];
+
+           return $posA <=> $posB;
+       });
+
+       foreach ($fetched as $item) {
+           $domainMessage = $normalizer->denormalize($item);
+
+           try {
+               $newEventStore->append(
+                   $domainMessage->getId(),
+                   new DomainEventStream([$domainMessage])
+               );
+           } catch (DuplicatePlayheadException) {
+               continue; // already written on a previous run
+           }
+       }
+   }
+   ```
+
+   Position assignments are deterministic — sorting by `RecordedOn` always produces the same order for the same data, so the same event receives the same `GlobalPosition` on every run. Skipping duplicates is safe.
+
+6. **Verify the new table** — compare total item counts and spot-check a few aggregate streams.
+
+7. **Cut over:** stop writes to the old table, update the table name in your application config to `events-table-v2`, redeploy.
+
+8. **Delete the old table** once you are confident the migration is complete.
+
+---
+
+## Option B: In-Place Backfill
+
+Modify the existing table without a full replay. Avoids a cutover window but requires writes to be paused for the duration of the backfill.
+
+### Preconditions
+
+- **Stop all writes** to the event store before starting. New appends after the new code is deployed but before the backfill completes will create the `_counter` item and write events with `GlobalPosition` values that conflict with the positions the backfill script is assigning.
+- If stopping writes is not possible, use Option A instead.
+
+### Steps
+
+1. **Add the GSI to the existing table.** DynamoDB will backfill it automatically for any items that already have `Feed` (none at this point, so it starts empty):
+
+   ```php
+   $client->updateTable([
+       'TableName'                  => 'events-table',
+       'AttributeDefinitions'       => [
+           ['AttributeName' => 'Feed',           'AttributeType' => 'S'],
+           ['AttributeName' => 'GlobalPosition', 'AttributeType' => 'N'],
+       ],
+       'GlobalSecondaryIndexUpdates' => [[
+           'Create' => [
+               'IndexName' => 'Feed-GlobalPosition-index',
+               'KeySchema' => [
+                   ['AttributeName' => 'Feed',           'KeyType' => 'HASH'],
+                   ['AttributeName' => 'GlobalPosition', 'KeyType' => 'RANGE'],
+               ],
+               'Projection' => ['ProjectionType' => 'ALL'],
+           ],
+       ]],
+   ]);
+
+   // tableExists() only checks the table status, not the GSI status.
+   // Poll DescribeTable until the GSI itself is ACTIVE.
+   do {
+       sleep(5);
+       $indexes = $client->describeTable(['TableName' => 'events-table'])
+           ->getTable()
+           ?->getGlobalSecondaryIndexes() ?? [];
+       $gsiStatus = null;
+       foreach ($indexes as $index) {
+           if ('Feed-GlobalPosition-index' === $index->getIndexName()) {
+               $gsiStatus = $index->getIndexStatus();
+               break;
+           }
+       }
+   } while ('ACTIVE' !== $gsiStatus);
+   ```
+
+2. **First pass — collect sort keys**, paginating through the full table:
+
+   ```php
+   $sortKeys         = [];
+   $lastEvaluatedKey = null;
+
+   do {
+       $params = ['TableName' => 'events-table'];
+
+       if (null !== $lastEvaluatedKey) {
+           $params['ExclusiveStartKey'] = $lastEvaluatedKey;
+       }
+
+       $result = $client->scan($params);
+
+       foreach ($result->getItems() as $item) {
+           if (!isset($item['Metadata'])) {
+               continue; // skip the _counter item if present
+           }
+
+           $sortKeys[] = [
+               'RecordedOn' => $item['RecordedOn']->getS(),
+               'Id'         => $item['Id']->getS(),
+               'Playhead'   => (int) $item['Playhead']->getN(),
+           ];
+       }
+
+       $lastEvaluatedKey = $result->getLastEvaluatedKey();
+   } while ([] !== $lastEvaluatedKey);
+   ```
+
+3. **Sort keys by `RecordedOn`**. The tiebreaker on `Id` and `Playhead` makes the sort stable when timestamps collide, which is required for idempotency:
+
+   ```php
+   usort($sortKeys, function ($a, $b) {
+       return $a['RecordedOn'] <=> $b['RecordedOn']
+           ?: $a['Id'] <=> $b['Id']
+           ?: $a['Playhead'] <=> $b['Playhead'];
+   });
+   ```
+
+4. **Second pass — update each item** in sorted order to add `Feed` and `GlobalPosition`. Positions start at 1 to match the behaviour of `append()`, which uses `ADD` on a counter that DynamoDB initialises to 0, so the first increment returns 1. The condition `attribute_not_exists(GlobalPosition)` makes each write a no-op if the item was already updated, so the script is safe to re-run after an interruption:
+
+   ```php
+   foreach ($sortKeys as $index => $key) {
+       $position = $index + 1; // 1-based, consistent with append()
+
+       try {
+           $client->updateItem([
+               'TableName'                 => 'events-table',
+               'Key'                       => [
+                   'Id'       => new AttributeValue(['S' => $key['Id']]),
+                   'Playhead' => new AttributeValue(['N' => (string) $key['Playhead']]),
+               ],
+               'ConditionExpression'       => 'attribute_not_exists(GlobalPosition)',
+               'UpdateExpression'          => 'SET Feed = :feed, GlobalPosition = :gp',
+               'ExpressionAttributeValues' => [
+                   ':feed' => new AttributeValue(['S' => 'all']),
+                   ':gp'   => new AttributeValue(['N' => (string) $position]),
+               ],
+           ]);
+       } catch (ConditionalCheckFailedException) {
+           continue; // already updated on a previous run
+       }
+   }
+   ```
+
+   Position assignments are deterministic — sorting by `RecordedOn` always produces the same order for the same data, so the same event receives the same `GlobalPosition` on every run.
+
+5. **Create the `_counter` item** with `Value` set to the total number of events — the last position assigned. Use a condition so that re-running the script after a crash does not overwrite a counter that may already have been advanced by concurrent writes:
+
+   ```php
+   $lastPosition = count($sortKeys); // 1-based: last assigned position equals total count
+
+   try {
+       $client->putItem([
+           'TableName'           => 'events-table',
+           'ConditionExpression' => 'attribute_not_exists(Id)',
+           'Item'                => [
+               'Id'       => new AttributeValue(['S' => '_counter']),
+               'Playhead' => new AttributeValue(['N' => '0']),
+               'Value'    => new AttributeValue(['N' => (string) $lastPosition]),
+           ],
+       ]);
+   } catch (ConditionalCheckFailedException) {
+       // Counter already exists. This is expected on a re-run after a crash.
+       // If writes were correctly stopped during the backfill, the existing value
+       // is the one this script wrote on a previous run and is safe to leave as-is.
+       // If writes were NOT stopped, investigate before resuming — the counter may
+       // have been advanced by concurrent appends and overwriting it would cause
+       // GlobalPosition collisions.
+   }
+   ```
+
+6. **Resume writes.** New appends will call `ADD` on the counter, receiving the next available position.
+
+---
+
+## Limitations of Both Approaches
+
+- **`RecordedOn` ordering is an approximation.** Broadway's `DateTime` stores microsecond precision (`Y-m-d\TH:i:s.uP`), so collisions are rare for sequential workloads. However, for concurrent appends — two processes calling `DateTime::now()` at the same time — timestamps can be identical or out-of-order relative to the actual DynamoDB commit sequence. The true interleaving at original append time is not stored anywhere in the table and cannot be recovered.
+
+- **Option B is not safe under concurrent writes.** Use Option A if you cannot guarantee a write-free window during the backfill.

--- a/docs/migrating-to-global-position.md
+++ b/docs/migrating-to-global-position.md
@@ -9,11 +9,11 @@ Each event row now has two additional attributes:
 - **`Feed`** (String) — always `'all'`; the hash key of the global replay index
 - **`GlobalPosition`** (Number) — a monotonically increasing counter assigned atomically at append time
 
-A Global Secondary Index (`Feed-GlobalPosition-index`) on `(Feed, GlobalPosition)` enables `visitEvents` to return events in the order they were committed and `visitEventsAfterGlobalPosition` to resume ordered replay from a checkpoint.
+A Global Secondary Index (`Feed-GlobalPosition-index`) on `(Feed, GlobalPosition)` enables `visitEvents` to return events in the order they were committed and `loadReplayPageAfterGlobalPosition` to resume ordered replay from a checkpoint.
 
 A special counter item (`Id=_counter, Playhead=0`) is maintained in the same table to allocate `GlobalPosition` ranges atomically.
 
-Existing rows without `Feed` and `GlobalPosition` will not appear in the GSI and will therefore be skipped by `visitEvents` and `visitEventsAfterGlobalPosition`.
+Existing rows without `Feed` and `GlobalPosition` will not appear in the GSI and will therefore be skipped by `visitEvents` and `loadReplayPageAfterGlobalPosition`.
 
 ---
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,25 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         cacheResultFile=".phpunit.cache/test-results"
-         executionOrder="depends,defects"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         convertDeprecationsToExceptions="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         verbose="true">
-    <testsuites>
-        <testsuite name="default">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <coverage cacheDirectory=".phpunit.cache/code-coverage"
-              processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="default">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="DYNAMODB_ENDPOINT" value="http://localhost:8000"/>
+    <env name="DYNAMODB_ACCESS_KEY_ID" value="fake"/>
+    <env name="DYNAMODB_SECRET_ACCESS_KEY" value="fake"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/DynamoDbEventStore.php
+++ b/src/DynamoDbEventStore.php
@@ -112,13 +112,9 @@ final class DynamoDbEventStore implements DynamoDbEventStoreInterface
 
     public function visitEvents(Criteria $criteria, EventVisitor $eventVisitor): void
     {
-        $result = $this->client->scan($this->inputBuilder->buildScanInput($this->table));
+        $result = $this->client->query($this->inputBuilder->buildGlobalReplayInput($this->table));
 
         foreach ($result->getItems() as $normalizedDomainMessage) {
-            if (!isset($normalizedDomainMessage['Metadata'])) {
-                continue;
-            }
-
             $domainMessage = $this->domainMessageNormalizer->denormalize($normalizedDomainMessage);
 
             if ($criteria->isMatchedBy($domainMessage)) {

--- a/src/DynamoDbEventStore.php
+++ b/src/DynamoDbEventStore.php
@@ -112,14 +112,26 @@ final class DynamoDbEventStore implements DynamoDbEventStoreInterface
 
     public function visitEvents(Criteria $criteria, EventVisitor $eventVisitor): void
     {
-        $result = $this->client->query($this->inputBuilder->buildGlobalReplayInput($this->table));
+        $this->visitEventsAfterGlobalPosition($criteria, 0, $eventVisitor);
+    }
+
+    public function visitEventsAfterGlobalPosition(Criteria $criteria, int $afterGlobalPosition, EventVisitor $eventVisitor): int
+    {
+        $lastProcessedGlobalPosition = $afterGlobalPosition;
+        $result                      = $this->client->query($this->inputBuilder->buildGlobalReplayInput($this->table, $afterGlobalPosition));
 
         foreach ($result->getItems() as $normalizedDomainMessage) {
-            $domainMessage = $this->domainMessageNormalizer->denormalize($normalizedDomainMessage);
+            if ('_counter' === $normalizedDomainMessage['Id']->getS()) {
+                continue;
+            }
 
+            $lastProcessedGlobalPosition = (int) $normalizedDomainMessage['GlobalPosition']->getN();
+            $domainMessage               = $this->domainMessageNormalizer->denormalize($normalizedDomainMessage);
             if ($criteria->isMatchedBy($domainMessage)) {
                 $eventVisitor->doWithEvent($domainMessage);
             }
         }
+
+        return $lastProcessedGlobalPosition;
     }
 }

--- a/src/DynamoDbEventStore.php
+++ b/src/DynamoDbEventStore.php
@@ -6,8 +6,8 @@ namespace chrisjenkinson\DynamoDbEventStore;
 
 use AsyncAws\DynamoDb\DynamoDbClient;
 use AsyncAws\DynamoDb\Exception\ConditionalCheckFailedException;
+use AsyncAws\DynamoDb\Exception\TransactionCanceledException;
 use Broadway\Domain\DomainEventStream;
-use Broadway\Domain\DomainMessage;
 use Broadway\EventStore\EventStreamNotFoundException;
 use Broadway\EventStore\EventVisitor;
 use Broadway\EventStore\Exception\DuplicatePlayheadException;
@@ -68,11 +68,25 @@ final class DynamoDbEventStore implements DynamoDbEventStoreInterface
             return;
         }
 
+        $lastReservedPosition = (int) $this->client
+            ->updateItem($this->inputBuilder->buildReserveGlobalPositionsInput($this->table, count($events)))
+            ->getAttributes()['Value']
+            ->getN();
+
+        $firstPosition = $lastReservedPosition - count($events) + 1;
+
+        $transactItems = [];
+
+        foreach ($events as $index => $domainMessage) {
+            $normalized                   = $this->domainMessageNormalizer->normalize($domainMessage);
+            $normalized['globalPosition'] = $firstPosition + $index;
+            $normalized['feed']           = 'all';
+            $transactItems[]              = $this->inputBuilder->buildTransactPutItem($this->table, $normalized);
+        }
+
         try {
-            array_map(function (DomainMessage $domainMessage): void {
-                $this->client->putItem($this->inputBuilder->buildPutItemInput($this->table, $this->domainMessageNormalizer->normalize($domainMessage)));
-            }, $events);
-        } catch (ConditionalCheckFailedException $e) {
+            $this->client->transactWriteItems($this->inputBuilder->buildTransactWriteItemsInput($transactItems));
+        } catch (ConditionalCheckFailedException | TransactionCanceledException $e) {
             throw new DuplicatePlayheadException($eventStream, $e);
         }
     }
@@ -101,6 +115,10 @@ final class DynamoDbEventStore implements DynamoDbEventStoreInterface
         $result = $this->client->scan($this->inputBuilder->buildScanInput($this->table));
 
         foreach ($result->getItems() as $normalizedDomainMessage) {
+            if (!isset($normalizedDomainMessage['Metadata'])) {
+                continue;
+            }
+
             $domainMessage = $this->domainMessageNormalizer->denormalize($normalizedDomainMessage);
 
             if ($criteria->isMatchedBy($domainMessage)) {

--- a/src/DynamoDbEventStore.php
+++ b/src/DynamoDbEventStore.php
@@ -19,7 +19,8 @@ final class DynamoDbEventStore implements DynamoDbEventStoreInterface
         private readonly DynamoDbClient $client,
         private readonly InputBuilder $inputBuilder,
         private readonly DomainMessageNormalizer $domainMessageNormalizer,
-        private readonly string $table
+        private readonly string $table,
+        private readonly bool $aggregateConsistentReads = false
     ) {
     }
 
@@ -27,7 +28,7 @@ final class DynamoDbEventStore implements DynamoDbEventStoreInterface
     {
         $id = (string) $id;
 
-        $result = $this->client->query($this->inputBuilder->buildQueryInput($this->table, $id));
+        $result = $this->client->query($this->inputBuilder->buildQueryInput($this->table, $id, $this->aggregateConsistentReads));
 
         if (0 === $result->getCount()) {
             throw new EventStreamNotFoundException(sprintf('Event stream not found for aggregate with id "%s" in table "%s"', $id, $this->table));
@@ -46,7 +47,7 @@ final class DynamoDbEventStore implements DynamoDbEventStoreInterface
     {
         $id = (string) $id;
 
-        $result = $this->client->query($this->inputBuilder->buildQueryWithPlayheadInput($this->table, $id, $playhead));
+        $result = $this->client->query($this->inputBuilder->buildQueryWithPlayheadInput($this->table, $id, $playhead, $this->aggregateConsistentReads));
 
         $events = [];
 

--- a/src/DynamoDbEventStore.php
+++ b/src/DynamoDbEventStore.php
@@ -112,26 +112,42 @@ final class DynamoDbEventStore implements DynamoDbEventStoreInterface
 
     public function visitEvents(Criteria $criteria, EventVisitor $eventVisitor): void
     {
-        $this->visitEventsAfterGlobalPosition($criteria, 0, $eventVisitor);
+        $checkpoint = 0;
+
+        do {
+            $page = $this->loadReplayPageAfterGlobalPosition($criteria, $checkpoint, 1000);
+
+            foreach ($page->events() as $event) {
+                $eventVisitor->doWithEvent($event->message());
+            }
+
+            $checkpoint = $page->lastProcessedGlobalPosition();
+        } while ($page->hasMore());
     }
 
-    public function visitEventsAfterGlobalPosition(Criteria $criteria, int $afterGlobalPosition, EventVisitor $eventVisitor): int
+    public function loadReplayPageAfterGlobalPosition(Criteria $criteria, int $afterGlobalPosition, int $limit): ReplayPage
     {
-        $lastProcessedGlobalPosition = $afterGlobalPosition;
-        $result                      = $this->client->query($this->inputBuilder->buildGlobalReplayInput($this->table, $afterGlobalPosition));
+        if ($limit < 1) {
+            throw new \InvalidArgumentException('Replay page limit must be at least 1.');
+        }
 
-        foreach ($result->getItems() as $normalizedDomainMessage) {
+        $lastProcessedGlobalPosition = $afterGlobalPosition;
+        $events                      = [];
+        $result                      = $this->client->query($this->inputBuilder->buildGlobalReplayInput($this->table, $afterGlobalPosition, $limit));
+
+        foreach ($result->getItems(true) as $normalizedDomainMessage) {
             if ('_counter' === $normalizedDomainMessage['Id']->getS()) {
                 continue;
             }
 
             $lastProcessedGlobalPosition = (int) $normalizedDomainMessage['GlobalPosition']->getN();
             $domainMessage               = $this->domainMessageNormalizer->denormalize($normalizedDomainMessage);
+
             if ($criteria->isMatchedBy($domainMessage)) {
-                $eventVisitor->doWithEvent($domainMessage);
+                $events[] = new ReplayEvent($domainMessage, $lastProcessedGlobalPosition);
             }
         }
 
-        return $lastProcessedGlobalPosition;
+        return new ReplayPage($events, $lastProcessedGlobalPosition, [] !== $result->getLastEvaluatedKey());
     }
 }

--- a/src/DynamoDbEventStore.php
+++ b/src/DynamoDbEventStore.php
@@ -20,7 +20,8 @@ final class DynamoDbEventStore implements DynamoDbEventStoreInterface
         private readonly InputBuilder $inputBuilder,
         private readonly DomainMessageNormalizer $domainMessageNormalizer,
         private readonly string $table,
-        private readonly bool $aggregateConsistentReads = false
+        private readonly bool $aggregateConsistentReads = false,
+        private readonly int $replayPageSize = 1000
     ) {
     }
 
@@ -115,7 +116,7 @@ final class DynamoDbEventStore implements DynamoDbEventStoreInterface
         $checkpoint = 0;
 
         do {
-            $page = $this->loadReplayPageAfterGlobalPosition($criteria, $checkpoint, 1000);
+            $page = $this->loadReplayPageAfterGlobalPosition($criteria, $checkpoint, $this->replayPageSize);
 
             foreach ($page->events() as $event) {
                 $eventVisitor->doWithEvent($event->message());

--- a/src/DynamoDbEventStoreInterface.php
+++ b/src/DynamoDbEventStoreInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace chrisjenkinson\DynamoDbEventStore;
 
 use Broadway\EventStore\EventStore;
-use Broadway\EventStore\EventVisitor;
 use Broadway\EventStore\Management\Criteria;
 use Broadway\EventStore\Management\EventStoreManagement;
 
@@ -15,5 +14,5 @@ interface DynamoDbEventStoreInterface extends EventStore, EventStoreManagement
 
     public function deleteTable(): void;
 
-    public function visitEventsAfterGlobalPosition(Criteria $criteria, int $afterGlobalPosition, EventVisitor $eventVisitor): int;
+    public function loadReplayPageAfterGlobalPosition(Criteria $criteria, int $afterGlobalPosition, int $limit): ReplayPage;
 }

--- a/src/DynamoDbEventStoreInterface.php
+++ b/src/DynamoDbEventStoreInterface.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace chrisjenkinson\DynamoDbEventStore;
 
 use Broadway\EventStore\EventStore;
+use Broadway\EventStore\EventVisitor;
+use Broadway\EventStore\Management\Criteria;
 use Broadway\EventStore\Management\EventStoreManagement;
 
 interface DynamoDbEventStoreInterface extends EventStore, EventStoreManagement
@@ -12,4 +14,6 @@ interface DynamoDbEventStoreInterface extends EventStore, EventStoreManagement
     public function createTable(): void;
 
     public function deleteTable(): void;
+
+    public function visitEventsAfterGlobalPosition(Criteria $criteria, int $afterGlobalPosition, EventVisitor $eventVisitor): int;
 }

--- a/src/InputBuilder.php
+++ b/src/InputBuilder.php
@@ -10,11 +10,15 @@ use AsyncAws\DynamoDb\Input\DescribeTableInput;
 use AsyncAws\DynamoDb\Input\PutItemInput;
 use AsyncAws\DynamoDb\Input\QueryInput;
 use AsyncAws\DynamoDb\Input\ScanInput;
+use AsyncAws\DynamoDb\Input\TransactWriteItemsInput;
+use AsyncAws\DynamoDb\Input\UpdateItemInput;
 use AsyncAws\DynamoDb\ValueObject\AttributeDefinition;
 use AsyncAws\DynamoDb\ValueObject\AttributeValue;
 use AsyncAws\DynamoDb\ValueObject\GlobalSecondaryIndex;
 use AsyncAws\DynamoDb\ValueObject\KeySchemaElement;
 use AsyncAws\DynamoDb\ValueObject\Projection;
+use AsyncAws\DynamoDb\ValueObject\Put;
+use AsyncAws\DynamoDb\ValueObject\TransactWriteItem;
 
 final class InputBuilder
 {
@@ -121,6 +125,94 @@ final class InputBuilder
                     ]),
                 ]),
             ],
+        ]);
+    }
+
+    public function buildReserveGlobalPositionsInput(string $tableName, int $count): UpdateItemInput
+    {
+        return new UpdateItemInput([
+            'TableName' => $tableName,
+            'Key'       => [
+                'Id' => new AttributeValue([
+                    'S' => '_counter',
+                ]),
+                'Playhead' => new AttributeValue([
+                    'N' => '0',
+                ]),
+            ],
+            'UpdateExpression'         => 'ADD #v :inc',
+            'ExpressionAttributeNames' => [
+                '#v' => 'Value',
+            ],
+            'ExpressionAttributeValues' => [
+                ':inc' => new AttributeValue([
+                    'N' => (string) $count,
+                ]),
+            ],
+            'ReturnValues' => 'UPDATED_NEW',
+        ]);
+    }
+
+    /**
+     * @param array{id: string, playhead: int, metadataClass: string, metadataPayload: string, payloadClass: string, payloadPayload: string, recordedOn: string, type: string, globalPosition: int, feed: string} $normalizedDomainMessage
+     */
+    public function buildTransactPutItem(string $tableName, array $normalizedDomainMessage): TransactWriteItem
+    {
+        return new TransactWriteItem([
+            'Put' => new Put([
+                'TableName'           => $tableName,
+                'ConditionExpression' => 'attribute_not_exists(Id)',
+                'Item'                => [
+                    'Id' => new AttributeValue([
+                        'S' => $normalizedDomainMessage['id'],
+                    ]),
+                    'Playhead' => new AttributeValue([
+                        'N' => (string) $normalizedDomainMessage['playhead'],
+                    ]),
+                    'Feed' => new AttributeValue([
+                        'S' => $normalizedDomainMessage['feed'],
+                    ]),
+                    'GlobalPosition' => new AttributeValue([
+                        'N' => (string) $normalizedDomainMessage['globalPosition'],
+                    ]),
+                    'Metadata' => new AttributeValue([
+                        'M' => [
+                            'Class' => new AttributeValue([
+                                'S' => $normalizedDomainMessage['metadataClass'],
+                            ]),
+                            'Payload' => new AttributeValue([
+                                'S' => $normalizedDomainMessage['metadataPayload'],
+                            ]),
+                        ],
+                    ]),
+                    'Payload' => new AttributeValue([
+                        'M' => [
+                            'Class' => new AttributeValue([
+                                'S' => $normalizedDomainMessage['payloadClass'],
+                            ]),
+                            'Payload' => new AttributeValue([
+                                'S' => $normalizedDomainMessage['payloadPayload'],
+                            ]),
+                        ],
+                    ]),
+                    'RecordedOn' => new AttributeValue([
+                        'S' => $normalizedDomainMessage['recordedOn'],
+                    ]),
+                    'Type' => new AttributeValue([
+                        'S' => $normalizedDomainMessage['type'],
+                    ]),
+                ],
+            ]),
+        ]);
+    }
+
+    /**
+     * @param TransactWriteItem[] $items
+     */
+    public function buildTransactWriteItemsInput(array $items): TransactWriteItemsInput
+    {
+        return new TransactWriteItemsInput([
+            'TransactItems' => $items,
         ]);
     }
 

--- a/src/InputBuilder.php
+++ b/src/InputBuilder.php
@@ -223,6 +223,7 @@ final class InputBuilder
         }
 
         return new QueryInput([
+            'ConsistentRead'            => false,
             'TableName'                 => $tableName,
             'IndexName'                 => 'Feed-GlobalPosition-index',
             'KeyConditionExpression'    => $keyCondition,

--- a/src/InputBuilder.php
+++ b/src/InputBuilder.php
@@ -206,6 +206,20 @@ final class InputBuilder
         ]);
     }
 
+    public function buildGlobalReplayInput(string $tableName): QueryInput
+    {
+        return new QueryInput([
+            'TableName'                 => $tableName,
+            'IndexName'                 => 'Feed-GlobalPosition-index',
+            'KeyConditionExpression'    => 'Feed = :feed',
+            'ExpressionAttributeValues' => [
+                ':feed' => new AttributeValue([
+                    'S' => 'all',
+                ]),
+            ],
+        ]);
+    }
+
     /**
      * @param TransactWriteItem[] $items
      */

--- a/src/InputBuilder.php
+++ b/src/InputBuilder.php
@@ -206,7 +206,7 @@ final class InputBuilder
         ]);
     }
 
-    public function buildGlobalReplayInput(string $tableName, ?int $afterGlobalPosition = null): QueryInput
+    public function buildGlobalReplayInput(string $tableName, ?int $afterGlobalPosition = null, ?int $limit = null): QueryInput
     {
         $keyCondition              = 'Feed = :feed';
         $expressionAttributeValues = [
@@ -228,6 +228,7 @@ final class InputBuilder
             'IndexName'                 => 'Feed-GlobalPosition-index',
             'KeyConditionExpression'    => $keyCondition,
             'ExpressionAttributeValues' => $expressionAttributeValues,
+            'Limit'                     => $limit,
         ]);
     }
 

--- a/src/InputBuilder.php
+++ b/src/InputBuilder.php
@@ -12,7 +12,9 @@ use AsyncAws\DynamoDb\Input\QueryInput;
 use AsyncAws\DynamoDb\Input\ScanInput;
 use AsyncAws\DynamoDb\ValueObject\AttributeDefinition;
 use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use AsyncAws\DynamoDb\ValueObject\GlobalSecondaryIndex;
 use AsyncAws\DynamoDb\ValueObject\KeySchemaElement;
+use AsyncAws\DynamoDb\ValueObject\Projection;
 
 final class InputBuilder
 {
@@ -81,6 +83,14 @@ final class InputBuilder
                     'AttributeName' => 'Playhead',
                     'AttributeType' => 'N',
                 ]),
+                new AttributeDefinition([
+                    'AttributeName' => 'Feed',
+                    'AttributeType' => 'S',
+                ]),
+                new AttributeDefinition([
+                    'AttributeName' => 'GlobalPosition',
+                    'AttributeType' => 'N',
+                ]),
             ],
             'BillingMode' => 'PAY_PER_REQUEST',
             'KeySchema'   => [
@@ -91,6 +101,24 @@ final class InputBuilder
                 new KeySchemaElement([
                     'AttributeName' => 'Playhead',
                     'KeyType'       => 'RANGE',
+                ]),
+            ],
+            'GlobalSecondaryIndexes' => [
+                new GlobalSecondaryIndex([
+                    'IndexName' => 'Feed-GlobalPosition-index',
+                    'KeySchema' => [
+                        new KeySchemaElement([
+                            'AttributeName' => 'Feed',
+                            'KeyType'       => 'HASH',
+                        ]),
+                        new KeySchemaElement([
+                            'AttributeName' => 'GlobalPosition',
+                            'KeyType'       => 'RANGE',
+                        ]),
+                    ],
+                    'Projection' => new Projection([
+                        'ProjectionType' => 'ALL',
+                    ]),
                 ]),
             ],
         ]);

--- a/src/InputBuilder.php
+++ b/src/InputBuilder.php
@@ -206,17 +206,27 @@ final class InputBuilder
         ]);
     }
 
-    public function buildGlobalReplayInput(string $tableName): QueryInput
+    public function buildGlobalReplayInput(string $tableName, ?int $afterGlobalPosition = null): QueryInput
     {
+        $keyCondition              = 'Feed = :feed';
+        $expressionAttributeValues = [
+            ':feed' => new AttributeValue([
+                'S' => 'all',
+            ]),
+        ];
+
+        if (null !== $afterGlobalPosition) {
+            $keyCondition .= ' AND GlobalPosition > :globalPosition';
+            $expressionAttributeValues[':globalPosition'] = new AttributeValue([
+                'N' => (string) $afterGlobalPosition,
+            ]);
+        }
+
         return new QueryInput([
             'TableName'                 => $tableName,
             'IndexName'                 => 'Feed-GlobalPosition-index',
-            'KeyConditionExpression'    => 'Feed = :feed',
-            'ExpressionAttributeValues' => [
-                ':feed' => new AttributeValue([
-                    'S' => 'all',
-                ]),
-            ],
+            'KeyConditionExpression'    => $keyCondition,
+            'ExpressionAttributeValues' => $expressionAttributeValues,
         ]);
     }
 

--- a/src/InputBuilder.php
+++ b/src/InputBuilder.php
@@ -16,9 +16,10 @@ use AsyncAws\DynamoDb\ValueObject\KeySchemaElement;
 
 final class InputBuilder
 {
-    public function buildQueryInput(string $tableName, string $id): QueryInput
+    public function buildQueryInput(string $tableName, string $id, bool $consistentRead = false): QueryInput
     {
         return new QueryInput([
+            'ConsistentRead'            => $consistentRead,
             'TableName'                 => $tableName,
             'KeyConditionExpression'    => 'Id = :id',
             'ExpressionAttributeValues' => [
@@ -29,9 +30,10 @@ final class InputBuilder
         ]);
     }
 
-    public function buildQueryWithPlayheadInput(string $tableName, string $id, int $playhead): QueryInput
+    public function buildQueryWithPlayheadInput(string $tableName, string $id, int $playhead, bool $consistentRead = false): QueryInput
     {
         return new QueryInput([
+            'ConsistentRead'            => $consistentRead,
             'TableName'                 => $tableName,
             'KeyConditionExpression'    => 'Id = :id AND Playhead >= :playhead',
             'ExpressionAttributeValues' => [

--- a/src/ReplayEvent.php
+++ b/src/ReplayEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbEventStore;
+
+use Broadway\Domain\DomainMessage;
+
+final class ReplayEvent
+{
+    public function __construct(
+        private readonly DomainMessage $message,
+        private readonly int $globalPosition
+    ) {
+    }
+
+    public function message(): DomainMessage
+    {
+        return $this->message;
+    }
+
+    public function globalPosition(): int
+    {
+        return $this->globalPosition;
+    }
+}

--- a/src/ReplayPage.php
+++ b/src/ReplayPage.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbEventStore;
+
+final class ReplayPage
+{
+    /**
+     * @param list<ReplayEvent> $events
+     */
+    public function __construct(
+        private readonly array $events,
+        private readonly int $lastProcessedGlobalPosition,
+        private readonly bool $hasMore
+    ) {
+    }
+
+    /**
+     * @return list<ReplayEvent>
+     */
+    public function events(): array
+    {
+        return $this->events;
+    }
+
+    public function lastProcessedGlobalPosition(): int
+    {
+        return $this->lastProcessedGlobalPosition;
+    }
+
+    public function hasMore(): bool
+    {
+        return $this->hasMore;
+    }
+}

--- a/tests/CollectingEventVisitor.php
+++ b/tests/CollectingEventVisitor.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbEventStore\Tests;
+
+use Broadway\Domain\DomainMessage;
+use Broadway\EventStore\EventVisitor;
+
+final class CollectingEventVisitor implements EventVisitor
+{
+    /**
+     * @var list<DomainMessage>
+     */
+    public array $visitedEvents = [];
+
+    public function doWithEvent(DomainMessage $domainMessage): void
+    {
+        $this->visitedEvents[] = $domainMessage;
+    }
+}

--- a/tests/DynamoDbEventStoreConsistencyTest.php
+++ b/tests/DynamoDbEventStoreConsistencyTest.php
@@ -7,7 +7,11 @@ namespace chrisjenkinson\DynamoDbEventStore\Tests;
 use AsyncAws\DynamoDb\DynamoDbClient;
 use AsyncAws\DynamoDb\Input\QueryInput;
 use AsyncAws\DynamoDb\Result\QueryOutput;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use Broadway\Domain\DomainMessage;
 use Broadway\EventStore\EventStreamNotFoundException;
+use Broadway\EventStore\EventVisitor;
+use Broadway\EventStore\Management\Criteria;
 use Broadway\Serializer\SimpleInterfaceSerializer;
 use chrisjenkinson\DynamoDbEventStore\DomainMessageNormalizer;
 use chrisjenkinson\DynamoDbEventStore\DynamoDbEventStore;
@@ -41,6 +45,105 @@ final class DynamoDbEventStoreConsistencyTest extends TestCase
 
         self::assertInstanceOf(QueryInput::class, $capturedInput);
         self::assertTrue($capturedInput->getConsistentRead());
+    }
+
+    public function test_it_uses_the_global_position_query_for_checkpoint_replay(): void
+    {
+        $capturedInput = null;
+        $eventStore    = $this->createEventStore($this->createQueryRecordingClient($capturedInput));
+
+        $lastProcessedGlobalPosition = $eventStore->visitEventsAfterGlobalPosition(
+            Criteria::create(),
+            7,
+            new class() implements EventVisitor {
+                public function doWithEvent(DomainMessage $domainMessage): void
+                {
+                }
+            }
+        );
+
+        self::assertSame(7, $lastProcessedGlobalPosition);
+        self::assertInstanceOf(QueryInput::class, $capturedInput);
+        self::assertSame('Feed-GlobalPosition-index', $capturedInput->getIndexName());
+        self::assertSame('Feed = :feed AND GlobalPosition > :globalPosition', $capturedInput->getKeyConditionExpression());
+        self::assertFalse($capturedInput->getConsistentRead());
+    }
+
+    public function test_it_does_not_surface_the_counter_row_during_checkpoint_replay(): void
+    {
+        $queryResult = $this->createStub(QueryOutput::class);
+        $queryResult->method('getItems')->willReturn([
+            [
+                'Id' => new AttributeValue([
+                    'S' => '_counter',
+                ]),
+                'Playhead' => new AttributeValue([
+                    'N' => '0',
+                ]),
+                'Feed' => new AttributeValue([
+                    'S' => 'all',
+                ]),
+                'GlobalPosition' => new AttributeValue([
+                    'N' => '1',
+                ]),
+            ],
+            [
+                'Id' => new AttributeValue([
+                    'S' => 'aggregate-id',
+                ]),
+                'Playhead' => new AttributeValue([
+                    'N' => '0',
+                ]),
+                'Feed' => new AttributeValue([
+                    'S' => 'all',
+                ]),
+                'GlobalPosition' => new AttributeValue([
+                    'N' => '2',
+                ]),
+                'Metadata' => new AttributeValue([
+                    'M' => [
+                        'Class' => new AttributeValue([
+                            'S' => 'Broadway\\Domain\\Metadata',
+                        ]),
+                        'Payload' => new AttributeValue([
+                            'S' => '[]',
+                        ]),
+                    ],
+                ]),
+                'Payload' => new AttributeValue([
+                    'M' => [
+                        'Class' => new AttributeValue([
+                            'S' => 'chrisjenkinson\\DynamoDbEventStore\\Tests\\TestEvent',
+                        ]),
+                        'Payload' => new AttributeValue([
+                            'S' => '{"id":"aggregate-id"}',
+                        ]),
+                    ],
+                ]),
+                'RecordedOn' => new AttributeValue([
+                    'S' => '2026-05-01T00:00:00.000000+00:00',
+                ]),
+                'Type' => new AttributeValue([
+                    'S' => 'chrisjenkinson\\DynamoDbEventStore\\Tests\\TestEvent',
+                ]),
+            ],
+        ]);
+
+        $client = $this->createStub(DynamoDbClient::class);
+        $client->method('query')->willReturn($queryResult);
+
+        $eventStore = $this->createEventStore($client);
+        $visitor    = new CollectingEventVisitor();
+
+        $lastProcessedGlobalPosition = $eventStore->visitEventsAfterGlobalPosition(
+            Criteria::create(),
+            0,
+            $visitor
+        );
+
+        self::assertSame(2, $lastProcessedGlobalPosition);
+        self::assertCount(1, $visitor->visitedEvents);
+        self::assertSame('aggregate-id', $visitor->visitedEvents[0]->getId());
     }
 
     private function createEventStore(DynamoDbClient $client, bool $aggregateConsistentReads = false): DynamoDbEventStore

--- a/tests/DynamoDbEventStoreConsistencyTest.php
+++ b/tests/DynamoDbEventStoreConsistencyTest.php
@@ -8,9 +8,7 @@ use AsyncAws\DynamoDb\DynamoDbClient;
 use AsyncAws\DynamoDb\Input\QueryInput;
 use AsyncAws\DynamoDb\Result\QueryOutput;
 use AsyncAws\DynamoDb\ValueObject\AttributeValue;
-use Broadway\Domain\DomainMessage;
 use Broadway\EventStore\EventStreamNotFoundException;
-use Broadway\EventStore\EventVisitor;
 use Broadway\EventStore\Management\Criteria;
 use Broadway\Serializer\SimpleInterfaceSerializer;
 use chrisjenkinson\DynamoDbEventStore\DomainMessageNormalizer;
@@ -18,6 +16,7 @@ use chrisjenkinson\DynamoDbEventStore\DynamoDbEventStore;
 use chrisjenkinson\DynamoDbEventStore\InputBuilder;
 use chrisjenkinson\DynamoDbEventStore\JsonDecoder;
 use chrisjenkinson\DynamoDbEventStore\JsonEncoder;
+use chrisjenkinson\DynamoDbEventStore\ReplayPage;
 use PHPUnit\Framework\TestCase;
 
 final class DynamoDbEventStoreConsistencyTest extends TestCase
@@ -47,29 +46,25 @@ final class DynamoDbEventStoreConsistencyTest extends TestCase
         self::assertTrue($capturedInput->getConsistentRead());
     }
 
-    public function test_it_uses_the_global_position_query_for_checkpoint_replay(): void
+    public function test_it_uses_the_global_position_query_for_replay_pages(): void
     {
         $capturedInput = null;
         $eventStore    = $this->createEventStore($this->createQueryRecordingClient($capturedInput));
 
-        $lastProcessedGlobalPosition = $eventStore->visitEventsAfterGlobalPosition(
-            Criteria::create(),
-            7,
-            new class() implements EventVisitor {
-                public function doWithEvent(DomainMessage $domainMessage): void
-                {
-                }
-            }
-        );
+        $page = $eventStore->loadReplayPageAfterGlobalPosition(Criteria::create(), 7, 3);
 
-        self::assertSame(7, $lastProcessedGlobalPosition);
         self::assertInstanceOf(QueryInput::class, $capturedInput);
         self::assertSame('Feed-GlobalPosition-index', $capturedInput->getIndexName());
         self::assertSame('Feed = :feed AND GlobalPosition > :globalPosition', $capturedInput->getKeyConditionExpression());
+        self::assertSame(3, $capturedInput->getLimit());
         self::assertFalse($capturedInput->getConsistentRead());
+        self::assertInstanceOf(ReplayPage::class, $page);
+        self::assertSame(7, $page->lastProcessedGlobalPosition());
+        self::assertFalse($page->hasMore());
+        self::assertSame([], $page->events());
     }
 
-    public function test_it_does_not_surface_the_counter_row_during_checkpoint_replay(): void
+    public function test_it_excludes_the_counter_row_from_replay_pages(): void
     {
         $queryResult = $this->createStub(QueryOutput::class);
         $queryResult->method('getItems')->willReturn([
@@ -128,22 +123,35 @@ final class DynamoDbEventStoreConsistencyTest extends TestCase
                 ]),
             ],
         ]);
+        $queryResult->method('getLastEvaluatedKey')->willReturn([]);
 
         $client = $this->createStub(DynamoDbClient::class);
         $client->method('query')->willReturn($queryResult);
 
-        $eventStore = $this->createEventStore($client);
-        $visitor    = new CollectingEventVisitor();
+        $page = $this->createEventStore($client)->loadReplayPageAfterGlobalPosition(Criteria::create(), 0, 1);
 
-        $lastProcessedGlobalPosition = $eventStore->visitEventsAfterGlobalPosition(
-            Criteria::create(),
-            0,
-            $visitor
-        );
+        self::assertCount(1, $page->events());
+        self::assertSame(2, $page->lastProcessedGlobalPosition());
+        self::assertFalse($page->hasMore());
+        self::assertSame('aggregate-id', $page->events()[0]->message()->getId());
+    }
 
-        self::assertSame(2, $lastProcessedGlobalPosition);
-        self::assertCount(1, $visitor->visitedEvents);
-        self::assertSame('aggregate-id', $visitor->visitedEvents[0]->getId());
+    public function test_it_reports_has_more_when_dynamodb_returns_a_continuation_key(): void
+    {
+        $queryResult = $this->createStub(QueryOutput::class);
+        $queryResult->method('getItems')->willReturn([]);
+        $queryResult->method('getLastEvaluatedKey')->willReturn([
+            'Id' => new AttributeValue([
+                'S' => 'aggregate-id',
+            ]),
+        ]);
+
+        $client = $this->createStub(DynamoDbClient::class);
+        $client->method('query')->willReturn($queryResult);
+
+        $page = $this->createEventStore($client)->loadReplayPageAfterGlobalPosition(Criteria::create(), 7, 3);
+
+        self::assertTrue($page->hasMore());
     }
 
     private function createEventStore(DynamoDbClient $client, bool $aggregateConsistentReads = false): DynamoDbEventStore

--- a/tests/DynamoDbEventStoreConsistencyTest.php
+++ b/tests/DynamoDbEventStoreConsistencyTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbEventStore\Tests;
+
+use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\Input\QueryInput;
+use AsyncAws\DynamoDb\Result\QueryOutput;
+use Broadway\EventStore\EventStreamNotFoundException;
+use Broadway\Serializer\SimpleInterfaceSerializer;
+use chrisjenkinson\DynamoDbEventStore\DomainMessageNormalizer;
+use chrisjenkinson\DynamoDbEventStore\DynamoDbEventStore;
+use chrisjenkinson\DynamoDbEventStore\InputBuilder;
+use chrisjenkinson\DynamoDbEventStore\JsonDecoder;
+use chrisjenkinson\DynamoDbEventStore\JsonEncoder;
+use PHPUnit\Framework\TestCase;
+
+final class DynamoDbEventStoreConsistencyTest extends TestCase
+{
+    public function test_it_uses_eventually_consistent_reads_for_aggregate_loads_by_default(): void
+    {
+        $capturedInput = null;
+        $eventStore    = $this->createEventStore($this->createQueryRecordingClient($capturedInput));
+
+        try {
+            $eventStore->load(new TestAggregateId('aggregate-id'));
+        } catch (EventStreamNotFoundException) {
+        }
+
+        self::assertInstanceOf(QueryInput::class, $capturedInput);
+        self::assertFalse($capturedInput->getConsistentRead());
+    }
+
+    public function test_it_can_use_strongly_consistent_reads_for_aggregate_playhead_loads(): void
+    {
+        $capturedInput = null;
+        $eventStore    = $this->createEventStore($this->createQueryRecordingClient($capturedInput), true);
+
+        $eventStore->loadFromPlayhead(new TestAggregateId('aggregate-id'), 0);
+
+        self::assertInstanceOf(QueryInput::class, $capturedInput);
+        self::assertTrue($capturedInput->getConsistentRead());
+    }
+
+    private function createEventStore(DynamoDbClient $client, bool $aggregateConsistentReads = false): DynamoDbEventStore
+    {
+        return new DynamoDbEventStore(
+            $client,
+            new InputBuilder(),
+            new DomainMessageNormalizer(new SimpleInterfaceSerializer(), new SimpleInterfaceSerializer(), new JsonEncoder(), new JsonDecoder()),
+            'table',
+            $aggregateConsistentReads
+        );
+    }
+
+    private function createQueryRecordingClient(?QueryInput &$capturedInput): DynamoDbClient
+    {
+        $queryResult = $this->createStub(QueryOutput::class);
+        $queryResult->method('getCount')->willReturn(0);
+        $queryResult->method('getItems')->willReturn([]);
+
+        $client = $this->createStub(DynamoDbClient::class);
+
+        $client->method('query')->willReturnCallback(static function (QueryInput $queryInput) use (&$capturedInput, $queryResult): QueryOutput {
+            $capturedInput = $queryInput;
+
+            return $queryResult;
+        });
+
+        return $client;
+    }
+}

--- a/tests/DynamoDbEventStoreConsistencyTest.php
+++ b/tests/DynamoDbEventStoreConsistencyTest.php
@@ -8,7 +8,9 @@ use AsyncAws\DynamoDb\DynamoDbClient;
 use AsyncAws\DynamoDb\Input\QueryInput;
 use AsyncAws\DynamoDb\Result\QueryOutput;
 use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use Broadway\Domain\DomainMessage;
 use Broadway\EventStore\EventStreamNotFoundException;
+use Broadway\EventStore\EventVisitor;
 use Broadway\EventStore\Management\Criteria;
 use Broadway\Serializer\SimpleInterfaceSerializer;
 use chrisjenkinson\DynamoDbEventStore\DomainMessageNormalizer;
@@ -154,14 +156,33 @@ final class DynamoDbEventStoreConsistencyTest extends TestCase
         self::assertTrue($page->hasMore());
     }
 
-    private function createEventStore(DynamoDbClient $client, bool $aggregateConsistentReads = false): DynamoDbEventStore
+    public function test_it_uses_the_configured_replay_page_size_when_visiting_events(): void
+    {
+        $capturedInput = null;
+        $eventStore    = $this->createEventStore($this->createQueryRecordingClient($capturedInput), replayPageSize: 25);
+
+        $eventStore->visitEvents(
+            Criteria::create(),
+            new class() implements EventVisitor {
+                public function doWithEvent(DomainMessage $domainMessage): void
+                {
+                }
+            }
+        );
+
+        self::assertInstanceOf(QueryInput::class, $capturedInput);
+        self::assertSame(25, $capturedInput->getLimit());
+    }
+
+    private function createEventStore(DynamoDbClient $client, bool $aggregateConsistentReads = false, int $replayPageSize = 1000): DynamoDbEventStore
     {
         return new DynamoDbEventStore(
             $client,
             new InputBuilder(),
             new DomainMessageNormalizer(new SimpleInterfaceSerializer(), new SimpleInterfaceSerializer(), new JsonEncoder(), new JsonDecoder()),
             'table',
-            $aggregateConsistentReads
+            $aggregateConsistentReads,
+            $replayPageSize
         );
     }
 

--- a/tests/DynamoDbEventStoreManagementTest.php
+++ b/tests/DynamoDbEventStoreManagementTest.php
@@ -20,9 +20,9 @@ final class DynamoDbEventStoreManagementTest extends EventStoreManagementTest
     protected function createEventStore(): EventStoreManagement
     {
         $client = new DynamoDbClient(Configuration::create([
-            'endpoint'        => 'http://dynamodb-local:8000',
-            'accessKeyId'     => '',
-            'accessKeySecret' => '',
+            'endpoint'        => (string) getenv('DYNAMODB_ENDPOINT'),
+            'accessKeyId'     => (string) getenv('DYNAMODB_ACCESS_KEY_ID'),
+            'accessKeySecret' => (string) getenv('DYNAMODB_SECRET_ACCESS_KEY'),
         ]));
         $inputBuilder            = new InputBuilder();
         $domainMessageNormalizer = new DomainMessageNormalizer(new SimpleInterfaceSerializer(), new SimpleInterfaceSerializer(), new JsonEncoder(), new JsonDecoder());

--- a/tests/DynamoDbEventStoreManagementTest.php
+++ b/tests/DynamoDbEventStoreManagementTest.php
@@ -17,6 +17,15 @@ use chrisjenkinson\DynamoDbEventStore\JsonEncoder;
 
 final class DynamoDbEventStoreManagementTest extends EventStoreManagementTest
 {
+    public function test_it_creates_a_global_position_index_for_replay(): void
+    {
+        $inputBuilder = new InputBuilder();
+        $input        = $inputBuilder->buildCreateTableInput('table');
+
+        self::assertSame('Feed', $input->getGlobalSecondaryIndexes()[0]->getKeySchema()[0]->getAttributeName());
+        self::assertSame('GlobalPosition', $input->getGlobalSecondaryIndexes()[0]->getKeySchema()[1]->getAttributeName());
+    }
+
     protected function createEventStore(): EventStoreManagement
     {
         $client = new DynamoDbClient(Configuration::create([

--- a/tests/DynamoDbEventStoreManagementTest.php
+++ b/tests/DynamoDbEventStoreManagementTest.php
@@ -57,6 +57,15 @@ final class DynamoDbEventStoreManagementTest extends EventStoreManagementTest
         self::assertSame($aggregateIdA, $lastTwo[1]->getId());
     }
 
+    public function test_it_can_query_replay_events_after_a_checkpoint(): void
+    {
+        $inputBuilder = new InputBuilder();
+        $input        = $inputBuilder->buildGlobalReplayInput('table', 7);
+
+        self::assertSame('Feed = :feed AND GlobalPosition > :globalPosition', $input->getKeyConditionExpression());
+        self::assertSame('7', $input->getExpressionAttributeValues()[':globalPosition']->getN());
+    }
+
     public function test_it_creates_a_global_position_index_for_replay(): void
     {
         $inputBuilder = new InputBuilder();

--- a/tests/DynamoDbEventStoreManagementTest.php
+++ b/tests/DynamoDbEventStoreManagementTest.php
@@ -57,6 +57,47 @@ final class DynamoDbEventStoreManagementTest extends EventStoreManagementTest
         self::assertSame($aggregateIdA, $lastTwo[1]->getId());
     }
 
+    public function test_it_loads_the_first_replay_page_in_global_position_order(): void
+    {
+        $aggregateIdB = 'aggregate-b';
+        $aggregateIdA = 'aggregate-a';
+
+        $this->dynamoEventStore->append($aggregateIdB, new DomainEventStream([
+            DomainMessage::recordNow($aggregateIdB, 0, new Metadata([]), new Start()),
+        ]));
+        $this->dynamoEventStore->append($aggregateIdA, new DomainEventStream([
+            DomainMessage::recordNow($aggregateIdA, 0, new Metadata([]), new Start()),
+        ]));
+
+        $page   = $this->dynamoEventStore->loadReplayPageAfterGlobalPosition(Criteria::create(), 24, 2);
+        $events = $page->events();
+
+        self::assertCount(2, $events);
+        self::assertSame($aggregateIdB, $events[0]->message()->getId());
+        self::assertSame(25, $events[0]->globalPosition());
+        self::assertSame($aggregateIdA, $events[1]->message()->getId());
+        self::assertSame(26, $events[1]->globalPosition());
+        self::assertSame(26, $page->lastProcessedGlobalPosition());
+    }
+
+    public function test_it_loads_a_later_page_after_a_checkpoint(): void
+    {
+        $aggregateId = 'aggregate-a';
+
+        $this->dynamoEventStore->append($aggregateId, new DomainEventStream([
+            DomainMessage::recordNow($aggregateId, 0, new Metadata([]), new Start()),
+            DomainMessage::recordNow($aggregateId, 1, new Metadata([]), new Start()),
+            DomainMessage::recordNow($aggregateId, 2, new Metadata([]), new Start()),
+        ]));
+
+        $page   = $this->dynamoEventStore->loadReplayPageAfterGlobalPosition(Criteria::create(), 25, 2);
+        $events = $page->events();
+
+        self::assertCount(2, $events);
+        self::assertSame(26, $events[0]->globalPosition());
+        self::assertSame(27, $events[1]->globalPosition());
+    }
+
     public function test_it_can_query_replay_events_after_a_checkpoint(): void
     {
         $inputBuilder = new InputBuilder();
@@ -66,53 +107,14 @@ final class DynamoDbEventStoreManagementTest extends EventStoreManagementTest
         self::assertSame('7', $input->getExpressionAttributeValues()[':globalPosition']->getN());
     }
 
-    public function test_it_replays_only_events_after_a_checkpoint_and_returns_the_last_processed_global_position(): void
+    public function test_it_can_query_replay_events_after_a_checkpoint_with_a_limit(): void
     {
-        $aggregateIdA = 'aggregate-a';
-        $aggregateIdB = 'aggregate-b';
+        $inputBuilder = new InputBuilder();
+        $input        = $inputBuilder->buildGlobalReplayInput('table', 7, 3);
 
-        $this->dynamoEventStore->append($aggregateIdA, new DomainEventStream([
-            DomainMessage::recordNow($aggregateIdA, 0, new Metadata([]), new Start()),
-        ]));
-        $this->dynamoEventStore->append($aggregateIdB, new DomainEventStream([
-            DomainMessage::recordNow($aggregateIdB, 0, new Metadata([]), new Start()),
-            DomainMessage::recordNow($aggregateIdB, 1, new Metadata([]), new Start()),
-        ]));
-
-        $visitor                     = new CollectingEventVisitor();
-        $lastProcessedGlobalPosition = $this->dynamoEventStore->visitEventsAfterGlobalPosition(
-            Criteria::create(),
-            25,
-            $visitor
-        );
-
-        $visitedEvents = $visitor->visitedEvents;
-        self::assertSame(27, $lastProcessedGlobalPosition);
-        self::assertCount(2, $visitedEvents);
-        self::assertSame($aggregateIdB, $visitedEvents[0]->getId());
-        self::assertSame(0, $visitedEvents[0]->getPlayhead());
-        self::assertSame($aggregateIdB, $visitedEvents[1]->getId());
-        self::assertSame(1, $visitedEvents[1]->getPlayhead());
-    }
-
-    public function test_it_returns_the_original_checkpoint_when_no_events_are_replayed(): void
-    {
-        $aggregateId = 'aggregate-a';
-
-        $this->dynamoEventStore->append($aggregateId, new DomainEventStream([
-            DomainMessage::recordNow($aggregateId, 0, new Metadata([]), new Start()),
-        ]));
-
-        $visitor                     = new CollectingEventVisitor();
-        $lastProcessedGlobalPosition = $this->dynamoEventStore->visitEventsAfterGlobalPosition(
-            Criteria::create(),
-            99,
-            $visitor
-        );
-
-        $visitedEvents = $visitor->visitedEvents;
-        self::assertSame(99, $lastProcessedGlobalPosition);
-        self::assertSame([], $visitedEvents);
+        self::assertSame('Feed = :feed AND GlobalPosition > :globalPosition', $input->getKeyConditionExpression());
+        self::assertSame('7', $input->getExpressionAttributeValues()[':globalPosition']->getN());
+        self::assertSame(3, $input->getLimit());
     }
 
     public function test_it_advances_the_checkpoint_past_filtered_events(): void
@@ -128,19 +130,40 @@ final class DynamoDbEventStoreManagementTest extends EventStoreManagementTest
             DomainMessage::recordNow($aggregateIdB, 1, new Metadata([]), new \Broadway\EventStore\Management\Testing\Middle('x')),
         ]));
 
-        $visitor                     = new CollectingEventVisitor();
-        $lastProcessedGlobalPosition = $this->dynamoEventStore->visitEventsAfterGlobalPosition(
+        $page = $this->dynamoEventStore->loadReplayPageAfterGlobalPosition(
             Criteria::create()->withEventTypes([
                 'Broadway.EventStore.Management.Testing.Start',
             ]),
             25,
-            $visitor
+            2
         );
 
-        self::assertSame(27, $lastProcessedGlobalPosition);
-        self::assertCount(1, $visitor->visitedEvents);
-        self::assertSame($aggregateIdB, $visitor->visitedEvents[0]->getId());
-        self::assertSame(0, $visitor->visitedEvents[0]->getPlayhead());
+        self::assertSame(27, $page->lastProcessedGlobalPosition());
+        self::assertCount(1, $page->events());
+        self::assertSame($aggregateIdB, $page->events()[0]->message()->getId());
+        self::assertSame(0, $page->events()[0]->message()->getPlayhead());
+    }
+
+    public function test_it_visits_all_events_by_draining_replay_pages(): void
+    {
+        $aggregateIdB = 'aggregate-b';
+        $aggregateIdA = 'aggregate-a';
+
+        $this->dynamoEventStore->append($aggregateIdB, new DomainEventStream([
+            DomainMessage::recordNow($aggregateIdB, 0, new Metadata([]), new Start()),
+        ]));
+        $this->dynamoEventStore->append($aggregateIdA, new DomainEventStream([
+            DomainMessage::recordNow($aggregateIdA, 0, new Metadata([]), new Start()),
+        ]));
+
+        $visitor = new RecordingEventVisitor();
+        $this->dynamoEventStore->visitEvents(Criteria::create(), $visitor);
+
+        $visitedEvents = $visitor->getVisitedEvents();
+        $lastTwo       = array_slice($visitedEvents, -2);
+
+        self::assertSame($aggregateIdB, $lastTwo[0]->getId());
+        self::assertSame($aggregateIdA, $lastTwo[1]->getId());
     }
 
     public function test_it_creates_a_global_position_index_for_replay(): void

--- a/tests/DynamoDbEventStoreManagementTest.php
+++ b/tests/DynamoDbEventStoreManagementTest.php
@@ -66,6 +66,83 @@ final class DynamoDbEventStoreManagementTest extends EventStoreManagementTest
         self::assertSame('7', $input->getExpressionAttributeValues()[':globalPosition']->getN());
     }
 
+    public function test_it_replays_only_events_after_a_checkpoint_and_returns_the_last_processed_global_position(): void
+    {
+        $aggregateIdA = 'aggregate-a';
+        $aggregateIdB = 'aggregate-b';
+
+        $this->dynamoEventStore->append($aggregateIdA, new DomainEventStream([
+            DomainMessage::recordNow($aggregateIdA, 0, new Metadata([]), new Start()),
+        ]));
+        $this->dynamoEventStore->append($aggregateIdB, new DomainEventStream([
+            DomainMessage::recordNow($aggregateIdB, 0, new Metadata([]), new Start()),
+            DomainMessage::recordNow($aggregateIdB, 1, new Metadata([]), new Start()),
+        ]));
+
+        $visitor                     = new CollectingEventVisitor();
+        $lastProcessedGlobalPosition = $this->dynamoEventStore->visitEventsAfterGlobalPosition(
+            Criteria::create(),
+            25,
+            $visitor
+        );
+
+        $visitedEvents = $visitor->visitedEvents;
+        self::assertSame(27, $lastProcessedGlobalPosition);
+        self::assertCount(2, $visitedEvents);
+        self::assertSame($aggregateIdB, $visitedEvents[0]->getId());
+        self::assertSame(0, $visitedEvents[0]->getPlayhead());
+        self::assertSame($aggregateIdB, $visitedEvents[1]->getId());
+        self::assertSame(1, $visitedEvents[1]->getPlayhead());
+    }
+
+    public function test_it_returns_the_original_checkpoint_when_no_events_are_replayed(): void
+    {
+        $aggregateId = 'aggregate-a';
+
+        $this->dynamoEventStore->append($aggregateId, new DomainEventStream([
+            DomainMessage::recordNow($aggregateId, 0, new Metadata([]), new Start()),
+        ]));
+
+        $visitor                     = new CollectingEventVisitor();
+        $lastProcessedGlobalPosition = $this->dynamoEventStore->visitEventsAfterGlobalPosition(
+            Criteria::create(),
+            99,
+            $visitor
+        );
+
+        $visitedEvents = $visitor->visitedEvents;
+        self::assertSame(99, $lastProcessedGlobalPosition);
+        self::assertSame([], $visitedEvents);
+    }
+
+    public function test_it_advances_the_checkpoint_past_filtered_events(): void
+    {
+        $aggregateIdA = 'aggregate-a';
+        $aggregateIdB = 'aggregate-b';
+
+        $this->dynamoEventStore->append($aggregateIdA, new DomainEventStream([
+            DomainMessage::recordNow($aggregateIdA, 0, new Metadata([]), new Start()),
+        ]));
+        $this->dynamoEventStore->append($aggregateIdB, new DomainEventStream([
+            DomainMessage::recordNow($aggregateIdB, 0, new Metadata([]), new Start()),
+            DomainMessage::recordNow($aggregateIdB, 1, new Metadata([]), new \Broadway\EventStore\Management\Testing\Middle('x')),
+        ]));
+
+        $visitor                     = new CollectingEventVisitor();
+        $lastProcessedGlobalPosition = $this->dynamoEventStore->visitEventsAfterGlobalPosition(
+            Criteria::create()->withEventTypes([
+                'Broadway.EventStore.Management.Testing.Start',
+            ]),
+            25,
+            $visitor
+        );
+
+        self::assertSame(27, $lastProcessedGlobalPosition);
+        self::assertCount(1, $visitor->visitedEvents);
+        self::assertSame($aggregateIdB, $visitor->visitedEvents[0]->getId());
+        self::assertSame(0, $visitor->visitedEvents[0]->getPlayhead());
+    }
+
     public function test_it_creates_a_global_position_index_for_replay(): void
     {
         $inputBuilder = new InputBuilder();

--- a/tests/DynamoDbEventStoreManagementTest.php
+++ b/tests/DynamoDbEventStoreManagementTest.php
@@ -6,8 +6,14 @@ namespace chrisjenkinson\DynamoDbEventStore\Tests;
 
 use AsyncAws\Core\Configuration;
 use AsyncAws\DynamoDb\DynamoDbClient;
+use Broadway\Domain\DomainEventStream;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use Broadway\EventStore\Management\Criteria;
 use Broadway\EventStore\Management\EventStoreManagement;
 use Broadway\EventStore\Management\Testing\EventStoreManagementTest;
+use Broadway\EventStore\Management\Testing\RecordingEventVisitor;
+use Broadway\EventStore\Management\Testing\Start;
 use Broadway\Serializer\SimpleInterfaceSerializer;
 use chrisjenkinson\DynamoDbEventStore\DomainMessageNormalizer;
 use chrisjenkinson\DynamoDbEventStore\DynamoDbEventStore;
@@ -17,6 +23,40 @@ use chrisjenkinson\DynamoDbEventStore\JsonEncoder;
 
 final class DynamoDbEventStoreManagementTest extends EventStoreManagementTest
 {
+    private DynamoDbEventStore $dynamoEventStore;
+
+    public function test_it_queries_events_by_global_position_for_replay(): void
+    {
+        $inputBuilder = new InputBuilder();
+        $input        = $inputBuilder->buildGlobalReplayInput('table');
+
+        self::assertSame('Feed-GlobalPosition-index', $input->getIndexName());
+        self::assertSame('Feed = :feed', $input->getKeyConditionExpression());
+        self::assertSame('all', $input->getExpressionAttributeValues()[':feed']->getS());
+    }
+
+    public function test_it_visits_events_in_global_position_order(): void
+    {
+        $aggregateIdB = 'aggregate-b';
+        $aggregateIdA = 'aggregate-a';
+
+        $this->dynamoEventStore->append($aggregateIdB, new DomainEventStream([
+            DomainMessage::recordNow($aggregateIdB, 0, new Metadata([]), new Start()),
+        ]));
+        $this->dynamoEventStore->append($aggregateIdA, new DomainEventStream([
+            DomainMessage::recordNow($aggregateIdA, 0, new Metadata([]), new Start()),
+        ]));
+
+        $visitor = new RecordingEventVisitor();
+        $this->dynamoEventStore->visitEvents(Criteria::create(), $visitor);
+        $visitedEvents = $visitor->getVisitedEvents();
+
+        $lastTwo = array_slice($visitedEvents, -2);
+
+        self::assertSame($aggregateIdB, $lastTwo[0]->getId());
+        self::assertSame($aggregateIdA, $lastTwo[1]->getId());
+    }
+
     public function test_it_creates_a_global_position_index_for_replay(): void
     {
         $inputBuilder = new InputBuilder();
@@ -40,6 +80,8 @@ final class DynamoDbEventStoreManagementTest extends EventStoreManagementTest
 
         $eventStore->deleteTable();
         $eventStore->createTable();
+
+        $this->dynamoEventStore = $eventStore;
 
         return $eventStore;
     }

--- a/tests/DynamoDbEventStoreTest.php
+++ b/tests/DynamoDbEventStoreTest.php
@@ -6,6 +6,7 @@ namespace chrisjenkinson\DynamoDbEventStore\Tests;
 
 use AsyncAws\Core\Configuration;
 use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\Exception\TransactionCanceledException;
 use AsyncAws\DynamoDb\Input\TransactWriteItemsInput;
 use AsyncAws\DynamoDb\Result\TransactWriteItemsOutput;
 use AsyncAws\DynamoDb\Result\UpdateItemOutput;
@@ -14,6 +15,7 @@ use Broadway\Domain\DomainEventStream;
 use Broadway\Domain\DomainMessage;
 use Broadway\Domain\Metadata;
 use Broadway\EventStore\EventStreamNotFoundException;
+use Broadway\EventStore\Exception\DuplicatePlayheadException;
 use Broadway\EventStore\Testing\EventStoreTest;
 use Broadway\Serializer\SimpleInterfaceSerializer;
 use chrisjenkinson\DynamoDbEventStore\DomainMessageNormalizer;
@@ -76,6 +78,30 @@ final class DynamoDbEventStoreTest extends EventStoreTest
         self::assertSame('all', $firstPut->getItem()['Feed']->getS());
         self::assertSame('0', $firstPut->getItem()['GlobalPosition']->getN());
         self::assertSame('1', $secondPut->getItem()['GlobalPosition']->getN());
+    }
+
+    public function test_it_translates_transaction_conflicts_to_duplicate_playhead(): void
+    {
+        $updateOutput = $this->createStub(UpdateItemOutput::class);
+        $updateOutput->method('getAttributes')->willReturn([
+            'Value' => new AttributeValue([
+                'N' => '0',
+            ]),
+        ]);
+
+        $client = $this->createStub(DynamoDbClient::class);
+        $client->method('updateItem')->willReturn($updateOutput);
+        /** @var TransactionCanceledException $transactionException */
+        $transactionException = (new \ReflectionClass(TransactionCanceledException::class))->newInstanceWithoutConstructor();
+        $client->method('transactWriteItems')->willThrowException($transactionException);
+
+        $eventStore = $this->createEventStoreWithClient($client);
+
+        $this->expectException(DuplicatePlayheadException::class);
+
+        $eventStore->append($this->aggregateId, new DomainEventStream([
+            $this->buildDomainMessage(0),
+        ]));
     }
 
     protected function setUp(): void

--- a/tests/DynamoDbEventStoreTest.php
+++ b/tests/DynamoDbEventStoreTest.php
@@ -34,9 +34,9 @@ final class DynamoDbEventStoreTest extends EventStoreTest
     protected function setUp(): void
     {
         $client = new DynamoDbClient(Configuration::create([
-            'endpoint'        => 'http://dynamodb-local:8000',
-            'accessKeyId'     => '',
-            'accessKeySecret' => '',
+            'endpoint'        => (string) getenv('DYNAMODB_ENDPOINT'),
+            'accessKeyId'     => (string) getenv('DYNAMODB_ACCESS_KEY_ID'),
+            'accessKeySecret' => (string) getenv('DYNAMODB_SECRET_ACCESS_KEY'),
         ]));
         $inputBuilder            = new InputBuilder();
         $domainMessageNormalizer = new DomainMessageNormalizer(new SimpleInterfaceSerializer(), new SimpleInterfaceSerializer(), new JsonEncoder(), new JsonDecoder());

--- a/tests/DynamoDbEventStoreTest.php
+++ b/tests/DynamoDbEventStoreTest.php
@@ -6,7 +6,13 @@ namespace chrisjenkinson\DynamoDbEventStore\Tests;
 
 use AsyncAws\Core\Configuration;
 use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\Input\TransactWriteItemsInput;
+use AsyncAws\DynamoDb\Result\TransactWriteItemsOutput;
+use AsyncAws\DynamoDb\Result\UpdateItemOutput;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
 use Broadway\Domain\DomainEventStream;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
 use Broadway\EventStore\EventStreamNotFoundException;
 use Broadway\EventStore\Testing\EventStoreTest;
 use Broadway\Serializer\SimpleInterfaceSerializer;
@@ -18,6 +24,8 @@ use chrisjenkinson\DynamoDbEventStore\JsonEncoder;
 
 final class DynamoDbEventStoreTest extends EventStoreTest
 {
+    private TestAggregateId $aggregateId;
+
     /**
      * @dataProvider idDataProvider
      * @param mixed $id
@@ -31,21 +39,74 @@ final class DynamoDbEventStoreTest extends EventStoreTest
         $this->eventStore->load($id);
     }
 
+    public function test_it_persists_global_position_metadata_for_each_event(): void
+    {
+        $capturedTransactItems = [];
+
+        $updateOutput = $this->createStub(UpdateItemOutput::class);
+        $updateOutput->method('getAttributes')->willReturn([
+            'Value' => new AttributeValue([
+                'N' => '1',
+            ]),
+        ]);
+
+        $client = $this->createStub(DynamoDbClient::class);
+        $client->method('updateItem')->willReturn($updateOutput);
+        $client->method('transactWriteItems')->willReturnCallback(
+            function ($input) use (&$capturedTransactItems): TransactWriteItemsOutput {
+                $capturedTransactItems = TransactWriteItemsInput::create($input)->getTransactItems();
+
+                return $this->createStub(TransactWriteItemsOutput::class);
+            }
+        );
+
+        $eventStore = $this->createEventStoreWithClient($client);
+
+        $eventStore->append($this->aggregateId, new DomainEventStream([
+            $this->buildDomainMessage(0),
+            $this->buildDomainMessage(1),
+        ]));
+
+        $firstPut  = $capturedTransactItems[0]->getPut();
+        $secondPut = $capturedTransactItems[1]->getPut();
+
+        self::assertNotNull($firstPut);
+        self::assertNotNull($secondPut);
+
+        self::assertSame('all', $firstPut->getItem()['Feed']->getS());
+        self::assertSame('0', $firstPut->getItem()['GlobalPosition']->getN());
+        self::assertSame('1', $secondPut->getItem()['GlobalPosition']->getN());
+    }
+
     protected function setUp(): void
     {
+        $this->aggregateId = new TestAggregateId('aggregate-id');
+
         $client = new DynamoDbClient(Configuration::create([
             'endpoint'        => (string) getenv('DYNAMODB_ENDPOINT'),
             'accessKeyId'     => (string) getenv('DYNAMODB_ACCESS_KEY_ID'),
             'accessKeySecret' => (string) getenv('DYNAMODB_SECRET_ACCESS_KEY'),
         ]));
+
+        $this->eventStore = $this->createEventStoreWithClient($client, true);
+    }
+
+    private function createEventStoreWithClient(DynamoDbClient $client, bool $createTable = false): DynamoDbEventStore
+    {
         $inputBuilder            = new InputBuilder();
         $domainMessageNormalizer = new DomainMessageNormalizer(new SimpleInterfaceSerializer(), new SimpleInterfaceSerializer(), new JsonEncoder(), new JsonDecoder());
+        $eventStore              = new DynamoDbEventStore($client, $inputBuilder, $domainMessageNormalizer, 'table');
 
-        $eventStore = new DynamoDbEventStore($client, $inputBuilder, $domainMessageNormalizer, 'table');
+        if ($createTable) {
+            $eventStore->deleteTable();
+            $eventStore->createTable();
+        }
 
-        $eventStore->deleteTable();
-        $eventStore->createTable();
+        return $eventStore;
+    }
 
-        $this->eventStore = $eventStore;
+    private function buildDomainMessage(int $playhead): DomainMessage
+    {
+        return DomainMessage::recordNow((string) $this->aggregateId, $playhead, new Metadata([]), new TestEvent($this->aggregateId));
     }
 }

--- a/tests/ReplayPageTest.php
+++ b/tests/ReplayPageTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbEventStore\Tests;
+
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use Broadway\EventStore\Management\Testing\Start;
+use chrisjenkinson\DynamoDbEventStore\ReplayEvent;
+use chrisjenkinson\DynamoDbEventStore\ReplayPage;
+use PHPUnit\Framework\TestCase;
+
+final class ReplayPageTest extends TestCase
+{
+    public function test_it_exposes_replay_events_checkpoint_and_has_more(): void
+    {
+        $message = DomainMessage::recordNow('aggregate-id', 0, new Metadata([]), new Start());
+        $event   = new ReplayEvent($message, 12);
+        $page    = new ReplayPage([$event], 12, true);
+
+        self::assertSame([$event], $page->events());
+        self::assertSame(12, $page->lastProcessedGlobalPosition());
+        self::assertTrue($page->hasMore());
+        self::assertSame($message, $event->message());
+        self::assertSame(12, $event->globalPosition());
+    }
+}

--- a/tests/TestAggregateId.php
+++ b/tests/TestAggregateId.php
@@ -6,8 +6,9 @@ namespace chrisjenkinson\DynamoDbEventStore\Tests;
 
 final class TestAggregateId
 {
-    public function __construct(public readonly string $id)
-    {
+    public function __construct(
+        public readonly string $id
+    ) {
     }
 
     public function __toString(): string

--- a/tests/TestEvent.php
+++ b/tests/TestEvent.php
@@ -8,8 +8,9 @@ use Broadway\Serializer\Serializable;
 
 final class TestEvent implements Serializable
 {
-    public function __construct(public readonly TestAggregateId $id)
-    {
+    public function __construct(
+        public readonly TestAggregateId $id
+    ) {
     }
 
     /**


### PR DESCRIPTION
Adds a monotonic `GlobalPosition` attribute to every event row, allocated atomically via a DynamoDB `ADD` counter and persisted transactionally with `TransactWriteItems`.

Adds a `Feed` attribute (always `'all'`) and a Global Secondary Index (`Feed-GlobalPosition-index`) so `visitEvents` can return events in commit order across aggregates.

Replaces the scan-based `visitEvents` with a GSI query ordered by `GlobalPosition`.

Adds an optional `afterGlobalPosition` checkpoint parameter to the GSI query builder for projection resumption.

Makes aggregate stream reads configurable between eventual and strong consistency.

Adds a migration guide (`docs/migrating-to-global-position.md`) covering table-swap and in-place backfill approaches, including idempotency, bulk fetching, and scale considerations.