### PR TITLE
Update CI PHP matrix and DynamoDB Local version

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,7 +15,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     services:
       dynamodb-local:
-        image: amazon/dynamodb-local:1.22.0
+        image: amazon/dynamodb-local:3.3.0
         ports:
           - 8000:8000/tcp
     strategy:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -9,17 +9,29 @@ permissions:
 
 jobs:
   build:
-    name: PHP ${{ matrix.php-versions }}
+    name: PHP ${{ matrix.php-version }}
     runs-on: ubuntu-latest
     container: ubuntu:latest
+    continue-on-error: ${{ matrix.experimental }}
     services:
       dynamodb-local:
         image: amazon/dynamodb-local:1.22.0
         ports:
           - 8000:8000/tcp
     strategy:
+      fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2', '8.3']
+        include:
+          - php-version: '8.1'
+            experimental: false
+          - php-version: '8.2'
+            experimental: false
+          - php-version: '8.3'
+            experimental: false
+          - php-version: '8.4'
+            experimental: true
+          - php-version: '8.5'
+            experimental: true
     env:
       DYNAMODB_ENDPOINT: 'http://dynamodb-local:8000'
       AWS_ACCESS_KEY_ID: 'none'
@@ -35,7 +47,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           tools: composer
           coverage: xdebug
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,6 @@ jobs:
     name: PHP ${{ matrix.php-version }}
     runs-on: ubuntu-latest
     container: ubuntu:latest
-    continue-on-error: ${{ matrix.experimental }}
     services:
       dynamodb-local:
         image: amazon/dynamodb-local:3.3.0
@@ -21,17 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - php-version: '8.1'
-            experimental: false
-          - php-version: '8.2'
-            experimental: false
-          - php-version: '8.3'
-            experimental: false
-          - php-version: '8.4'
-            experimental: true
-          - php-version: '8.5'
-            experimental: true
+        php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
     env:
       DYNAMODB_ENDPOINT: 'http://dynamodb-local:8000'
       AWS_ACCESS_KEY_ID: 'none'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   dynamodb-local:
-    image: amazon/dynamodb-local:latest
+    image: amazon/dynamodb-local:3.3.0
     command: -jar DynamoDBLocal.jar -inMemory
     ports:
       - "8000:8000"


### PR DESCRIPTION
Adds PHP 8.4 and 8.5 to CI, keeps the full matrix non-fail-fast, and updates DynamoDB Local to 3.3.0.